### PR TITLE
新規投稿機能を作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'rails-controller-testing'
   gem 'pry-rails'
   gem 'pry-byebug'
   gem 'pry-doc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -293,6 +297,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.1)
+  rails-controller-testing
   rspec-rails
   rubocop
   sass-rails (~> 5.0)

--- a/app/assets/stylesheets/partials/posts/new.scss
+++ b/app/assets/stylesheets/partials/posts/new.scss
@@ -1,0 +1,11 @@
+.new-post {
+  height: calc(100vh - 50px);
+  background-color: white;
+  h1 {
+    text-align: center;
+    margin: 25px 0;
+  }
+  input, textarea, select {
+    width: 100%;
+  }
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,21 @@
 class PostsController < ApplicationController
+  before_action :redirect_if_not_signed_in, only: [:new]
+
+  def new
+    @branch = params[:branch]
+    @categories = Category.where(branch: @branch)
+    @post = Post.new
+  end
+
+  def create
+    @post = Post.new(post_params)
+    if @post.save
+      redirect_to post_path(@post)
+    else
+      redirect_to root_path
+    end
+  end
+
   def show
     @post = Post.find(params[:id])
   end
@@ -32,5 +49,17 @@ class PostsController < ApplicationController
       category: params[:category],
       branch: params[:action]
     ).call
+  end
+
+  def post_params
+    params.require(:post).permit(:content, :title, :category_id).merge(user_id: current_user.id)
+  end
+
+  def redirect_if_not_signed_in
+    redirect_to root_path unless user_signed_in?
+  end
+
+  def redirect_if_signed_in
+    redirect_to root_path if user_signed_in?
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,8 @@
 class Post < ApplicationRecord
+  validates :title, presence: true, length: { minimum: 5, maximum: 255 }
+  validates :content, presence: true, length: { minimum: 20, maximum: 1000 }
+  validates :category_id, presence: true
+
   belongs_to :user
   belongs_to :category
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,8 @@
+<div class="container new-post">
+  <div class="row">
+    <div class="col-sm-6 col-sm-offset-3">
+      <h1>Create a new post</h1>
+        <%= render 'posts/new/post_form' %>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/new/_post_form.html.erb
+++ b/app/views/posts/new/_post_form.html.erb
@@ -1,0 +1,18 @@
+<%= bootstrap_form_for(@post) do |f| %>
+  <%= f.text_field  :title, 
+                    placeholder: 'Title', 
+                    class: 'form-control',
+                    required: true, 
+                    minlength: 5,
+                    maxlength: 100 %>
+  <%= f.hidden_field :branch, :value => @branch %>
+  <%= f.text_area :content, 
+                  rows: 6,
+                  required: true, 
+                  minlength: 20,
+                  maxlength: 1000,
+                  placeholder: 'Describe what you are looking for. E.g. specific interests, expertise level, etc.', 
+                  class: 'form-control' %>
+  <%= f.collection_select :category_id, @categories, :id, :name, class: 'form-control' %>
+  <%= f.submit "Create a post", class: 'form-control' %>
+<% end %>

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,6 +1,54 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do # rubocop:disable Metrics/BlockLength
+  context 'Validations' do # rubocop:disable Metrics/BlockLength
+    let(:post) { build(:post) }
+
+    it 'creates successfully' do
+      expect(post).to be_valid
+    end
+
+    it 'is not valid without a category' do
+      post.category_id = nil
+      expect(post).not_to be_valid
+    end
+
+    it 'is not valid without a title' do
+      post.title = nil
+      expect(post).not_to be_valid
+    end
+
+    it 'is not valid  without a user_id' do
+      post.user_id = nil
+      expect(post).not_to be_valid
+    end
+
+    it 'is not valid  with a title, shorter than 5 characters' do
+      post.title = 'a' * 4
+      expect(post).not_to be_valid
+    end
+
+    it 'is not valid  with a title, longer than 255 characters' do
+      post.title = 'a' * 260
+      expect(post).not_to be_valid
+    end
+
+    it 'is not valid without a content' do
+      post.content = nil
+      expect(post).not_to be_valid
+    end
+
+    it 'is not valid  with a content, shorter than 20 characters' do
+      post.content = 'a' * 10
+      expect(post).not_to be_valid
+    end
+
+    it 'is not valid  with a content, longer than 1000 characters' do
+      post.content = 'a' * 1050
+      expect(post).not_to be_valid
+    end
+  end
+
   context 'Associations' do
     it 'belongs_to user' do
       association = described_class.reflect_on_association(:user).macro

--- a/spec/requests/posts/branches_spec.rb
+++ b/spec/requests/posts/branches_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+include Warden::Test::Helpers # rubocop:disable Style/MixinUsage
+
+RSpec.describe 'branches', type: :request do
+  shared_examples 'render_templates' do
+    it 'renders a hobby template' do
+      get '/posts/hobby'
+      expect(response).to render_template(:hobby)
+    end
+
+    it 'renders a study template' do
+      get '/posts/study'
+      expect(response).to render_template(:study)
+    end
+
+    it 'renders a team template' do
+      get '/posts/team'
+      expect(response).to render_template(:team)
+    end
+  end
+
+  context 'non-signed in user' do
+    it_behaves_like 'render_templates'
+  end
+
+  context 'signed in user' do
+    let(:user) { create(:user) }
+    before(:each) { login_as user }
+
+    it_behaves_like 'render_templates'
+  end
+end

--- a/spec/requests/posts/create_new_post_spec.rb
+++ b/spec/requests/posts/create_new_post_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.feature 'Create a new post', type: :feature do
+  let(:user) { create(:user) }
+  before(:each) { sign_in user }
+
+  shared_examples 'user creates a new post' do |branch|
+    scenario 'successfully' do
+      create(:category, name: 'category', branch: branch)
+      visit send("#{branch}_posts_path")
+      find('.new-post-button').click
+      fill_in 'post[title]', with: 'a' * 20
+      fill_in 'post[content]', with: 'a' * 20
+      select 'category', from: 'post[category_id]'
+      click_on 'Create a post'
+      expect(page).to have_selector('h3', text: 'a' * 20)
+    end
+  end
+
+  include_examples 'user creates a new post', 'hobby'
+  include_examples 'user creates a new post', 'study'
+  include_examples 'user creates a new post', 'team'
+end

--- a/spec/requests/posts/new_spec.rb
+++ b/spec/requests/posts/new_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+include Warden::Test::Helpers # rubocop:disable Style/MixinUsage
+
+RSpec.describe 'new', type: :request do
+  context 'non-signed in user' do
+    it 'redirects to a root path' do
+      get '/posts/new'
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context 'signed in user' do
+    let(:user) { create(:user) }
+    before(:each) { login_as user }
+
+    it 'renders a new template' do
+      get '/posts/new'
+      expect(response).to render_template(:new)
+    end
+  end
+end

--- a/spec/requests/posts/show_spec.rb
+++ b/spec/requests/posts/show_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+include Warden::Test::Helpers # rubocop:disable Style/MixinUsage
+
+RSpec.describe 'show', type: :request do
+  shared_examples 'render_show_template' do
+    let(:post) { create(:post) }
+    it 'renders a show template' do
+      get post_path(post)
+      expect(response).to render_template(:show)
+    end
+  end
+
+  context 'non-signed in user' do
+    it_behaves_like 'render_show_template'
+  end
+
+  context 'signed in user' do
+    let(:user) { create(:user) }
+    before(:each) { login_as user }
+
+    it_behaves_like 'render_show_template'
+  end
+end


### PR DESCRIPTION
` include Warden::Test::Helpers`
wikiによるとDevise::TestHelpersが使えないようなのでDeviseの核となっているWardenのTestHelperを使用している。
https://qiita.com/seimiyajun/items/96441cca00d8bf9f97e6

`Style/MixinUsage`
include複数のモジュールを含むクラスのための位置を自動的に決定することは困難であるため、自動修正は提供されない。現在は` # rubocop:disable Style/MixinUsage`と警告を出さないようにしている。
https://rubocop.readthedocs.io/en/latest/cops_style/#stylemixinusage
https://rubocop.readthedocs.io/en/latest/cops_style/#stylemixinusage
https://pocke.hatenablog.com/entry/2017/10/21/144830
